### PR TITLE
Fix chisel-testers version to work with 1.2.5 <= x < 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ resolvers ++= Seq(
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
   "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "1.2.5+"
+  "chisel-iotesters" -> "[1.2.5,1.3.0["
   )
 
 libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {


### PR DESCRIPTION
See https://ant.apache.org/ivy/history/2.3.0/ivyfile/dependency.html#revision

(**Note** - this is for release versions.)
