### PR TITLE
Avoid SNAPSHOTs for release version.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ resolvers ++= Seq(
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
   "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "[1.2.5,1.3.0["
+  "chisel-iotesters" -> "[1.2.5,1.3.0-SNAPSHOT["
   )
 
 libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {


### PR DESCRIPTION
According to https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8855, "All versions with a qualifier are older than the same version without a qualifier (release version)." which means that specifying:
```
"chisel-iotesters" -> "[1.2.5,1.3.0["
```
as a version range, causes sbt-ivy to pull in 1.3-SNAPSHOT (now that we publish SNAPSHOTs) and eventually (due to dependencies), the SNAPSHOT versions of the rest of the BIG5. Use the fictitious "1.3.0-SNAPSHOT" version as the (exclusive) upper limit on the range.

NOTE: This is only for the release version. The master (development) version should include dependencies on SNAPSHOTs.
