### PR TITLE
Avoid SNAPSHOTs for release version - take 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ resolvers ++= Seq(
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
   "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "[1.2.5,1.3.0-SNAPSHOT["
+  "chisel-iotesters" -> "[1.2.5,1.3-SNAPSHOT["
   )
 
 libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {


### PR DESCRIPTION
Apparently "1.3-SNAPSHOT" < "1.3.0-SNAPSHOT". Update (reduce) upper range appropriately.