### PR TITLE
Bump versions for 3.2.0 release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,11 +28,11 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 
 name := "chisel-module-template"
 
-version := "3.1.1"
+version := "3.2.0"
 
 scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+crossScalaVersions := Seq("2.11.12", "2.12.10")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
@@ -41,8 +41,8 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "[1.2.5,1.3-SNAPSHOT["
+  "chisel3" -> "3.2.+",
+  "chisel-iotesters" -> "1.3.+"
   )
 
 libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,9 @@ name := "chisel-module-template"
 
 version := "3.2.0"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.12", "2.12.10")
+crossScalaVersions := Seq("2.12.10", "2.11.12")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.3.2


### PR DESCRIPTION
**NOTE** This PR is against the `release` branch. It bumps versions for the just-released [chisel3 3.2.0.](https://github.com/freechipsproject/chisel3/releases/tag/v3.2.0) These changes will be cherry-picked into `master`.

Normally, we'd make these changes to `master` and merge/cherry-pick them into `release`, but `master` is currently too far ahead (it includes a dependency on [testers2](https://github.com/ucb-bar/chisel-testers2) which hasn't been published yet).