### PR TITLE
Bump versions for 3.2.0 release. (#55)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,9 @@ name := "chisel-module-template"
 
 version := "3.2-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.12", "2.12.6")
+crossScalaVersions := Seq("2.12.10", "2.11.12")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.3.2


### PR DESCRIPTION
This applies #55 to master.

* Bump versions for 3.2.0 release.

* Switch to Scala 2.12 as the "default".

(cherry picked from commit 783d6d8b6ad9a89887e5b6f713db78515308e5c4)