### PR TITLE
Remove confusing comment

### DIFF
--- a/src/test/scala/gcd/GCDUnitTest.scala
+++ b/src/test/scala/gcd/GCDUnitTest.scala
@@ -62,7 +62,6 @@ class GCDUnitTester(c: GCD) extends PeekPokeTester(c) {
   * }}}
   */
 class GCDTester extends ChiselFlatSpec {
-  // Disable this until we fix isCommandAvailable to swallow stderr along with stdout
   private val backendNames = if(firrtl.FileUtils.isCommandAvailable(Seq("verilator", "--version"))) {
     Array("firrtl", "verilator")
   }


### PR DESCRIPTION
Apparently, the Verilator backend used to be disabled because stderr could not be properly captured, this has been fixed so this comment was outdated and confusing.