### PR TITLE
Fixed failing vcd generation with treadle

### DIFF
--- a/src/test/scala/gcd/GCDUnitTest.scala
+++ b/src/test/scala/gcd/GCDUnitTest.scala
@@ -110,7 +110,7 @@ class GCDTester extends ChiselFlatSpec {
       c => new GCDUnitTester(c)
     } should be(true)
 
-    new File("test_run_dir/make_a_vcd/make_a_vcd.vcd").exists should be (true)
+    new File("test_run_dir/make_a_vcd/GCD.vcd").exists should be (true)
   }
 
   "running with --generate-vcd-output off" should "not create a vcd file from your test" in {


### PR DESCRIPTION
File name being generated is wrong
I believe this is a result of new way that --top-name works. Simple fix for now is to change file name being searched for. This should not be a problem when we move to newer flags based on stage phase.