### PR TITLE
Change into educational example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,38 @@
 // See README.md for license details.
 
-ThisBuild / organization := "edu.berkeley.cs"
+// Common properties shared for a whole build
 ThisBuild / scalaVersion := "2.12.12"
-ThisBuild / version      := "3.3-SNAPSHOT"
+// These settings are mainly for publishing, they should be customized by the user
+ThisBuild / organization := "edu.berkeley.cs"
+ThisBuild / version      := "3.3-SNAPSHOT" // SNAPSHOT is used to indicate development
 
+// A project is a compilation unit
+// Many projects are fine with just one (like this example), but complex builds may have multiple
+// The properties scoped in "ThisBuild" above are shared between all projects
 lazy val chiselTemplate = (project in file("."))
   .settings(
     name := "chisel-module-template",
     libraryDependencies ++= Seq(
+      // Fundamentally, Chisel is just a Scala library, so we depend on it as a library
+      // Chisel 3 is versioning is of the style "3.<major>.<minor>"
+      // Chisel maintains binary compatibility between minor versions
+      // We use '+' to pull newest minor version
       "edu.berkeley.cs" %% "chisel3" % "3.3.+",
+      // By default, dependencies are in the "main" scope, projects also have a "test" scope
+      // main code lives in "src/main/", test is found in "src/test/"
+      // The following depenencies will only be available in "src/test/"
       "edu.berkeley.cs" %% "chisel-iotesters" % "1.4.+" % "test",
+      // Leading with a 0 indicates less stability so it's generally good to pin a specific version,
+      // It's also reasonable to pin specific versions for the above dependencies as well
       "edu.berkeley.cs" %% "chiseltest" % "0.2.2" % "test"
     ),
     scalacOptions ++= Seq(
+      // Required options for Chisel code
       "-Xsource:2.11",
+      // Recommended options
+      "-language:reflectiveCalls",
       "-deprecation",
       "-feature",
-      "-language:reflectiveCalls",
       "-Xcheckinit"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,55 +1,23 @@
 // See README.md for license details.
 
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
+ThisBuild / organization := "edu.berkeley.cs"
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / version      := "3.3-SNAPSHOT"
 
-def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // Scala 2.12 requires Java 8. We continue to generate
-    //  Java 7 compatible code for Scala 2.11
-    //  for compatibility with old clients.
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-        Seq("-source", "1.7", "-target", "1.7")
-      case _ =>
-        Seq("-source", "1.8", "-target", "1.8")
-    }
-  }
-}
-
-name := "chisel-module-template"
-
-version := "3.3-SNAPSHOT"
-
-scalaVersion := "2.12.10"
-
-crossScalaVersions := Seq("2.12.10", "2.11.12")
-
-resolvers ++= Seq(
-  Resolver.sonatypeRepo("snapshots"),
-  Resolver.sonatypeRepo("releases")
-)
-
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-
-// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-val defaultVersions = Seq(
-  "chisel-iotesters" -> "1.5-SNAPSHOT",
-  "chiseltest" -> "0.3-SNAPSHOT"
+lazy val chiselTemplate = (project in file("."))
+  .settings(
+    name := "chisel-module-template",
+    libraryDependencies ++= Seq(
+      "edu.berkeley.cs" %% "chisel3" % "3.3.+",
+      "edu.berkeley.cs" %% "chisel-iotesters" % "1.4.+" % "test",
+      "edu.berkeley.cs" %% "chiseltest" % "0.2.2" % "test"
+    ),
+    scalacOptions ++= Seq(
+      "-Xsource:2.11",
+      "-deprecation",
+      "-feature",
+      "-language:reflectiveCalls",
+      "-Xcheckinit"
+    )
   )
 
-libraryDependencies ++= defaultVersions.map { case (dep, ver) =>
-  "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", ver) }
-
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
-
-javacOptions ++= javacOptionsVersion(scalaVersion.value)


### PR DESCRIPTION
This PR is partially intended to spark discussion about what the chisel-template should be. Historically, I think there have been two competing concerns: education vs. template for repeated use. This PR is an attempt to pull more toward the education side since this is the example build to which we point new users. Others may disagree, but whatever we do I think the style of `build.sbt` I'm proposing here should exist _somewhere_.

Another opinion I have is that there really should not be a `master` vs. `release` of this repository. I think this should exist as purely a stable example (using normal releases). If someone wants to switch to the bleeding edge I think we should just encourage them to update the versions in this repository rather than checking out `master` instead of `release.

Another thought, perhaps we should move this to a `g8` template since it is a little strange to start a project by inheriting a ton of git history. `sbt new chipsalliance/chisel-template.g8` would give a better starting point with no git history (although we should obviously encourage users to use version control).