### PR TITLE
Fix some warnings deprecation with chisel version 3.5.1

### DIFF
--- a/src/main/scala/gcd/DecoupledGCD.scala
+++ b/src/main/scala/gcd/DecoupledGCD.scala
@@ -23,7 +23,7 @@ class GcdOutputBundle(val w: Int) extends Bundle {
   * Unless first input is zero then the Gcd is y.
   * Can handle stalls on the producer or consumer side
   */
-class DecoupledGcd(width: Int) extends MultiIOModule {
+class DecoupledGcd(width: Int) extends Module {
   val input = IO(Flipped(Decoupled(new GcdInputBundle(width))))
   val output = IO(Decoupled(new GcdOutputBundle(width)))
 

--- a/src/test/scala/gcd/GCDSpec.scala
+++ b/src/test/scala/gcd/GCDSpec.scala
@@ -4,7 +4,7 @@ package gcd
 
 import chisel3._
 import chiseltest._
-import org.scalatest.AnyFreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 import chisel3.experimental.BundleLiterals._
 
 /**


### PR DESCRIPTION
I had some warnings using the main branch of this template. Here are the fixes.