### PR TITLE
bump sbt version to 1.8.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.9
+sbt.version = 1.8.0


### PR DESCRIPTION
Current sbt version 1.4.9 is causing the following error:
```
[error] [launcher] error during sbt launcher: java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
```
