### PR TITLE
Bump versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,17 @@
 // See README.md for license details.
 
-ThisBuild / scalaVersion     := "2.13.8"
+ThisBuild / scalaVersion     := "2.13.12"
 ThisBuild / version          := "0.1.0"
 ThisBuild / organization     := "%ORGANIZATION%"
 
-val chiselVersion = "5.0.0"
+val chiselVersion = "5.1.0"
 
 lazy val root = (project in file("."))
   .settings(
     name := "%NAME%",
     libraryDependencies ++= Seq(
       "org.chipsalliance" %% "chisel" % chiselVersion,
-      "edu.berkeley.cs" %% "chiseltest" % "5.0.0" % "test"
+      "edu.berkeley.cs" %% "chiseltest" % "5.0.2" % "test"
     ),
     scalacOptions ++= Seq(
       "-language:reflectiveCalls",
@@ -19,7 +19,6 @@ lazy val root = (project in file("."))
       "-feature",
       "-Xcheckinit",
       "-Ymacro-annotations",
-      "-P:chiselplugin:genBundleElements",
     ),
     addCompilerPlugin("org.chipsalliance" % "chisel-plugin" % chiselVersion cross CrossVersion.full),
   )

--- a/build.sc
+++ b/build.sc
@@ -7,25 +7,24 @@ import scalalib._
 // support BSP
 import mill.bsp._
 
-object %NAME% extends SbtModule { m =>
+object foo extends SbtModule { m =>
   override def millSourcePath = os.pwd
-  override def scalaVersion = "2.13.8"
+  override def scalaVersion = "2.13.12"
   override def scalacOptions = Seq(
     "-language:reflectiveCalls",
     "-deprecation",
     "-feature",
     "-Xcheckinit",
-    "-P:chiselplugin:genBundleElements"
   )
   override def ivyDeps = Agg(
-    ivy"org.chipsalliance::chisel:5.0.0",
+    ivy"org.chipsalliance::chisel:5.1.0",
   )
   override def scalacPluginIvyDeps = Agg(
-    ivy"org.chipsalliance:::chisel-plugin:5.0.0",
+    ivy"org.chipsalliance:::chisel-plugin:5.1.0",
   )
   object test extends SbtModuleTests with TestModule.ScalaTest {
     override def ivyDeps = m.ivyDeps() ++ Agg(
-      ivy"edu.berkeley.cs::chiseltest:5.0.0"
+      ivy"edu.berkeley.cs::chiseltest:5.0.2"
     )
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.0
+sbt.version = 1.9.7


### PR DESCRIPTION
* chisel: 5.0.0 => 5.1.0
* chiseltest: 5.0.0 => 5.0.2
* scala: 2.13.8 => 2.13.12
* sbt: 1.8.0 => 1.9.7

Also remove -P:chiselplugin:genBundleElements, it has been deprecated for a while.